### PR TITLE
アプリケーションのPort番号を標準出力に出力する

### DIFF
--- a/src/main/java/jp/co/flect/heroku/training/HelloServlet.java
+++ b/src/main/java/jp/co/flect/heroku/training/HelloServlet.java
@@ -14,6 +14,7 @@ public class HelloServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
 		System.out.println("TEST_VARIABLE   : " + System.getenv("TEST_VARIABLE"));
+		System.out.println("Heroku App PORT   : " + System.getenv("PORT"));
 		res.getWriter().print("Hello World!");
 		res.getWriter().print("Good afternoon World!");
 		res.getWriter().print("Good evening World!");


### PR DESCRIPTION
デモの一部としてPaperTrailによりPort番号を確認する内容があるので
標準出力にアプリケーションのPort番号を出力するようにする
